### PR TITLE
[MTDB-11460] Fix positioning of Advertisement section

### DIFF
--- a/src/components/Advertisement.tsx
+++ b/src/components/Advertisement.tsx
@@ -42,13 +42,19 @@ const adlist = [
   },
 ];
 
-const AdWrapper = styled.div`
+const AdWrapper = styled.div<{ $mobileVersion?: boolean }>`
   color: #899bb5;
   font-size: 0.75rem;
   font-weight: 400;
   padding: 1rem;
   max-width: 32rem;
   margin: auto;
+  display: ${({ $mobileVersion }) => ($mobileVersion ? "block" : "none")};
+
+  @media (min-width: 768px) {
+    padding: 1rem 0;
+    display: ${({ $mobileVersion }) => ($mobileVersion ? "none" : "block")};
+  }
 `;
 
 const AdImage = styled.img`
@@ -59,7 +65,11 @@ const AdImage = styled.img`
   border-radius: 0.5rem;
 `;
 
-const Advertisement: FC = () => {
+interface Props {
+  mobileVersion?: boolean;
+}
+
+const Advertisement: FC<Props> = ({ mobileVersion }) => {
   const [rand, setRand] = useState(Math.floor(Math.random() * adlist.length));
 
   useEffect(() => {
@@ -71,7 +81,7 @@ const Advertisement: FC = () => {
   }, []);
 
   return (
-    <AdWrapper>
+    <AdWrapper $mobileVersion={mobileVersion}>
       <div>Advertisement</div>
       <a href={adlist[rand].link} target="_blank" rel="noreferrer">
         <AdImage src={adlist[rand].img} width="100%" />

--- a/src/components/Advertisement.tsx
+++ b/src/components/Advertisement.tsx
@@ -56,6 +56,7 @@ const AdImage = styled.img`
   height: auto;
   max-width: 100%;
   margin-top: 0.5rem;
+  border-radius: 0.5rem;
 `;
 
 const Advertisement: FC = () => {

--- a/src/components/GameBoard/GameBoard.tsx
+++ b/src/components/GameBoard/GameBoard.tsx
@@ -56,6 +56,7 @@ const GameBoard: FC = () => {
         </TabContent>
       </ShopSection>
       <Boosts mobileVersion />
+      <Advertisement mobileVersion />
     </StyledGameBoard>
   );
 };

--- a/src/components/Shop/ShopList/ShopList.tsx
+++ b/src/components/Shop/ShopList/ShopList.tsx
@@ -62,8 +62,8 @@ const ShopList: FC<Props> = ({ toggleOpen, setToggleOpen }) => {
         </BuildingsWrapper>
         <BottomShadow />
         <CookiesDisplay />
+        <Advertisement />
       </Wrapper>
-      <Advertisement />
     </>
   );
 };


### PR DESCRIPTION
- position under buildings/upgrades on bigger screen
- position under boosts on smaller screen
- add radius to ad image
<img width="1717" alt="Screenshot 2023-10-26 at 16 43 27" src="https://github.com/bitcoin-verse/verse-clicker/assets/94164690/8e043fcc-ef69-4aaa-abe3-88251ff516b1">
<img width="375" alt="Screenshot 2023-10-26 at 16 43 56" src="https://github.com/bitcoin-verse/verse-clicker/assets/94164690/08098ab5-ddce-4f84-80aa-3d66bf923e49">
