### PR TITLE
[MTDB-11475] Update farm modal design

### DIFF
--- a/src/components/Boosts/Boosts.tsx
+++ b/src/components/Boosts/Boosts.tsx
@@ -52,7 +52,7 @@ const getModalContent = (content?: string) => {
       };
     case "farm":
       return {
-        title: "Double CPS!",
+        title: "Farms/Staking",
         component: <Farm />,
       };
     default:

--- a/src/components/Boosts/Boosts.tsx
+++ b/src/components/Boosts/Boosts.tsx
@@ -20,10 +20,10 @@ import {
 } from "./styled";
 import Check from "../Icons/Check";
 
-const boostList = (unlocked: boolean) => [
+const boostList = (verseHolder: boolean, isFarmsOrStaking: boolean) => [
   {
     id: "hold",
-    unlocked: unlocked,
+    unlocked: verseHolder,
     label: "Hold",
   },
   {
@@ -33,7 +33,7 @@ const boostList = (unlocked: boolean) => [
   },
   {
     id: "farm",
-    unlocked: unlocked,
+    unlocked: isFarmsOrStaking,
     label: "Farm",
   },
 ];
@@ -70,13 +70,14 @@ const Boosts: FC<Props> = ({ mobileVersion }) => {
   const { player } = useTrackedState();
 
   const modalContent = getModalContent(content);
+  const isFarmsOrStaking = player.isFarming || player.isStaking;
 
   return (
     <Wrapper $mobileVersion={mobileVersion}>
       <Content>
         <H4>Boost your points</H4>
         <BoostTiles>
-          {boostList(player.verseHolder).map((boost) => (
+          {boostList(player.verseHolder, isFarmsOrStaking).map((boost) => (
             <BoostButton
               key={boost.id}
               onClick={() => {

--- a/src/components/Boosts/Modals/Farm.tsx
+++ b/src/components/Boosts/Modals/Farm.tsx
@@ -1,21 +1,48 @@
 import React, { FC } from "react";
 
+import { Chip } from "../../Chip";
+import { H3 } from "../../H3";
+import { LinkButton } from "../../LinkButton";
+import { Label } from "../../Label";
+
+import { ModalWrapper } from "../styled";
+import { useTrackedState } from "../../../context/store";
+
 const Farm: FC = () => {
+  const { player } = useTrackedState();
+
   return (
-    <>
-      <div>Have verse staked or locked in a farm for a 2xCPS multiplier</div>
-      <div>
-        To start farming go check out{" "}
-        <a
-          href="https://verse.bitcoin.com/farms"
-          target="_blank"
-          rel="noreferrer"
-        >
-          VERSE DEX
-        </a>{" "}
-        NOW!
-      </div>
-    </>
+    <ModalWrapper>
+      <Chip>10x boost</Chip>
+      {player.verseHolder ? (
+        <>
+          <H3>You&#39;re currently farming and/or staking VERSE</H3>
+          <Label $color="secondary">10x boost applied to your clicks</Label>
+        </>
+      ) : (
+        <>
+          <H3>You&#39;re currently not farming or staking any VERSE</H3>
+          <Label $color="secondary">
+            Farm or Stake VERSE to boost your point production
+          </Label>
+          <LinkButton
+            href="https://verse.bitcoin.com/farms/eth/"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Farm VERSE
+          </LinkButton>
+          <LinkButton
+            $design="secondary"
+            href="https://verse.bitcoin.com/staking/eth/verse/"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Stake VERSE
+          </LinkButton>
+        </>
+      )}
+    </ModalWrapper>
   );
 };
 

--- a/src/components/Boosts/Modals/Farm.tsx
+++ b/src/components/Boosts/Modals/Farm.tsx
@@ -14,7 +14,7 @@ const Farm: FC = () => {
   return (
     <ModalWrapper>
       <Chip>10x boost</Chip>
-      {player.verseHolder ? (
+      {player.isFarming || player.isStaking ? (
         <>
           <H3>You&#39;re currently farming and/or staking VERSE</H3>
           <Label $color="secondary">10x boost applied to your clicks</Label>

--- a/src/context/reducers/player.ts
+++ b/src/context/reducers/player.ts
@@ -10,6 +10,8 @@ export type Player = {
     Spent: number;
   };
   verseHolder: boolean;
+  isFarming: boolean;
+  isStaking: boolean;
 };
 
 export type SetPlayerAction = { type: "SET_PLAYER_DATA"; payload: Player };

--- a/src/context/store.ts
+++ b/src/context/store.ts
@@ -43,6 +43,8 @@ export const initialState: State = {
       Spent: 0,
     },
     verseHolder: false,
+    isFarming: false,
+    isStaking: false,
   },
   network: "Ethereum",
   purchaseAmount: 1,


### PR DESCRIPTION
- dev designed since there's no design for this, just reused hold modal's content
- add `isFarming` and `isStaking` to `Player` object
- use `isFarming` and `isStaking` to display diff content on modal

**Doesn't have farms or staking**
<img width="359" alt="Screenshot 2023-10-27 at 10 34 57" src="https://github.com/bitcoin-verse/verse-clicker/assets/94164690/77604146-6378-4728-a8a1-88621168f3a7">
<img width="446" alt="Screenshot 2023-10-27 at 10 36 32" src="https://github.com/bitcoin-verse/verse-clicker/assets/94164690/cbbc4d2b-94c4-440f-90c1-f7f4cbe096f6">

**Has farms or staking**
<img width="369" alt="Screenshot 2023-10-27 at 10 38 16" src="https://github.com/bitcoin-verse/verse-clicker/assets/94164690/ee2408ba-bf2b-45d9-8663-816ef289c21b">

<img width="423" alt="Screenshot 2023-10-27 at 10 38 02" src="https://github.com/bitcoin-verse/verse-clicker/assets/94164690/feae601c-9063-4e17-a894-7fb49cfec136">
