### PR TITLE
[MTDB-11311] Remove unlock text and display boosts in one line

### DIFF
--- a/src/components/Boosts/Boosts.tsx
+++ b/src/components/Boosts/Boosts.tsx
@@ -89,9 +89,7 @@ const Boosts: FC<Props> = ({ mobileVersion }) => {
                 {boost.unlocked ? <Check /> : <Lock />}
                 {boost.label}
               </Label>
-              <Boost $unlocked={boost.unlocked}>
-                {!boost.unlocked && "Unlock"} 10x boost
-              </Boost>
+              <Boost $unlocked={boost.unlocked}>10x boost</Boost>
             </BoostButton>
           ))}
         </BoostTiles>

--- a/src/components/Boosts/styled.ts
+++ b/src/components/Boosts/styled.ts
@@ -21,17 +21,7 @@ export const Content = styled.div`
 export const BoostTiles = styled.div`
   display: flex;
   gap: 1rem;
-  max-width: calc(100vw);
-  overflow-x: auto;
-  overflow-y: visible;
   padding: 1rem 0;
-
-  @media (min-width: 768px) {
-    display: grid;
-    gap: 1rem;
-    grid-template-columns: 1fr 1fr;
-    overflow: visible;
-  }
 `;
 
 export const BoostButton = styled.button`


### PR DESCRIPTION
<img width="596" alt="Screenshot 2023-10-27 at 12 26 28" src="https://github.com/bitcoin-verse/verse-clicker/assets/94164690/54806395-0862-4f79-9f6f-6b0dd448866b">
<img width="316" alt="Screenshot 2023-10-27 at 12 26 49" src="https://github.com/bitcoin-verse/verse-clicker/assets/94164690/4f1f5f59-457c-4b51-b59a-f9a22382c450">
