### PR TITLE
[MTDB-11629] tweak instructions and styles in welcome modal

### DIFF
--- a/src/components/WelcomeModal/NewUser.tsx
+++ b/src/components/WelcomeModal/NewUser.tsx
@@ -9,22 +9,21 @@ const NewUser = () => {
         Click for Verse points, climb the leaderboard! Join the Verse community
         and experience a world of endless clicking fun.
       </Description>
+      <Description style={{ textAlign: 'left', width: '100%' }}>
+        <span>The goal:</span>
+        <br />
+        Generate infinite Verse Points.
+      </Description>
       <Description style={{ textAlign: 'left' }}>
-        Here is how to play:
+        <span>How to play:</span>
+        <br />
+        1. Earn Verse Points by clicking on the Verse Clicker logo.
         <br />
         <br />
-        1. Click the Verse moon to earn points
+        2. Use Verse Points to buy Tools and Upgrades that automatically generate more Verse Points.
         <br />
         <br />
-        2. Buy Tools and Upgrades with your points to passively generate
-        more points
-        <br />
-        <br />
-        3. Boost your clicking power by holding, farming, staking, and/or
-        burning VERSE        
-        <br />
-        <br />
-        4. Keep clicking and buying to see the number go up!
+        3. Optionally use VERSE tokens to boost your Verse Points generation.  
       </Description>
     </>
   );

--- a/src/components/WelcomeModal/styled.ts
+++ b/src/components/WelcomeModal/styled.ts
@@ -39,4 +39,8 @@ export const Description = styled.div`
   font-weight: 500;
   font-size: 0.875rem;
   color: ${colors.shade80};
+
+  & > span {
+    color: ${colors.white}
+  }
 `;


### PR DESCRIPTION
i went with option #3 but took some liberties lol

> like this option the best but with some tweaks:
> - should say Verse Clicker logo as it’s not exactly the verse logo
> - switching order of Tools and Upgrades and capitalize maybe(??) since that’s the order they’re displayed in
> - use the word boost instead of supercharge since that’s what is used in the boost section

<img width="411" alt="Screenshot 2023-11-02 at 5 02 55 PM" src="https://github.com/bitcoin-verse/verse-clicker/assets/65150922/bacf6eb2-8119-477c-bb80-919b89fa25e5">
