### PR TITLE
[MTDB-11622] Feature/leaderboard

### DIFF
--- a/src/components/GameBoard/Stats/Stats.tsx
+++ b/src/components/GameBoard/Stats/Stats.tsx
@@ -17,8 +17,9 @@ const Stats: FC = () => {
     const leaderboardIndex = leaderboard?.findIndex(
       (item) => item.address === address,
     );
-    if (leaderboardIndex === undefined) {
-      return ">25";
+
+    if (leaderboardIndex === undefined || leaderboardIndex >= 10) {
+      return ">10";
     }
     return leaderboardIndex + 1;
   }, [leaderboard]);

--- a/src/components/Icons/Cursor.tsx
+++ b/src/components/Icons/Cursor.tsx
@@ -1,0 +1,28 @@
+import React, { ComponentPropsWithoutRef, FC } from "react";
+
+interface Props extends ComponentPropsWithoutRef<"svg"> {
+  size?: number | string;
+}
+
+const Cursor: FC<Props> = ({ size = 12 }) => {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M9 3.5V2M5.06066 5.06066L4 4M5.06066 13L4 14.0607M13 5.06066L14.0607 4M3.5 9H2M8.5 8.5L12.6111 21.2778L15.5 18.3889L19.1111 22L22 19.1111L18.3889 15.5L21.2778 12.6111L8.5 8.5Z"
+        stroke="currentColor"
+        fill="white"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+};
+
+export default Cursor;

--- a/src/components/Sidebar/Leaderboard/Leaderboard.tsx
+++ b/src/components/Sidebar/Leaderboard/Leaderboard.tsx
@@ -8,13 +8,12 @@ import {
   Body,
   Header,
   LeaderboardWrapper,
-  MoonImage,
   StarWrapper,
   YouBadge,
 } from "./styled";
 
-import cookieImg from "../../../assets/verse-moon-small.png";
 import Star from "../../Icons/Star";
+import Cursor from "../../Icons/Cursor";
 
 const Leaderboard = () => {
   const { address } = useAccount();
@@ -41,7 +40,7 @@ const Leaderboard = () => {
                 </div>
                 <div>
                   {formatNumber(Number(item.stats.Clicked))}{" "}
-                  <MoonImage src={cookieImg} alt="cookie" />
+                  <Cursor size="0.875rem" />
                 </div>
                 <div>
                   {formatNumber(Number(item.stats.Earned))}
@@ -65,7 +64,7 @@ const Leaderboard = () => {
             </div>
             <div>
               {formatNumber(Number(item.stats.Clicked))}{" "}
-              <MoonImage src={cookieImg} alt="cookie" />
+              <Cursor size="0.875rem" />
             </div>
             <div>
               {formatNumber(Number(item.stats.Earned))}

--- a/src/components/Sidebar/Leaderboard/Leaderboard.tsx
+++ b/src/components/Sidebar/Leaderboard/Leaderboard.tsx
@@ -30,6 +30,32 @@ const Leaderboard = () => {
       </Header>
 
       {leaderboard?.map((item, index) => {
+        if (index >= 10) {
+          if (item.address === address) {
+            return (
+              <Body key={item.address}>
+                <div>...</div>
+                <div>
+                  {truncateEthAddress(item.address)}{" "}
+                  {item.address === address && <YouBadge>🌟</YouBadge>}
+                </div>
+                <div>
+                  {formatNumber(Number(item.stats.Clicked))}{" "}
+                  <MoonImage src={cookieImg} alt="cookie" />
+                </div>
+                <div>
+                  {formatNumber(Number(item.stats.Earned))}
+                  <StarWrapper>
+                    <Star size="0.875rem" />
+                  </StarWrapper>
+                </div>
+              </Body>
+            );
+          }
+
+          return null;
+        }
+
         return (
           <Body key={item.address}>
             <div>{index + 1}</div>

--- a/src/components/Sidebar/Leaderboard/styled.ts
+++ b/src/components/Sidebar/Leaderboard/styled.ts
@@ -27,13 +27,6 @@ export const YouBadge = styled.div`
   background: linear-gradient(180deg, #425472 0%, #313e57 100%);
 `;
 
-export const MoonImage = styled.img`
-  height: 0.875rem;
-  width: 0.875rem;
-
-  filter: drop-shadow(0px 2px 10px #1167b6);
-`;
-
 export const Header = styled.div`
   display: grid;
   grid-template-columns: 1rem auto 6rem 6rem;

--- a/src/components/Sidebar/Leaderboard/styled.ts
+++ b/src/components/Sidebar/Leaderboard/styled.ts
@@ -79,4 +79,9 @@ export const Body = styled.div`
     text-align: left;
     justify-content: flex-start;
   }
+
+  & > :nth-child(3),
+  & > :nth-child(4) {
+    font-family: monospace;
+  }
 `;


### PR DESCRIPTION
- limit leaderboard list to 10
- add cursor instead of verse icon to clicks
- use monospace font for numbers
- add user at bottom of leaderboard if not top 10

<img width="423" alt="image" src="https://github.com/bitcoin-verse/verse-clicker/assets/3693256/df2e773f-c80d-4044-83eb-6c5e473a8774">
