### PR TITLE
increase leaderboard size and add scrolling

### DIFF
--- a/src/components/GameBoard/Stats/Stats.tsx
+++ b/src/components/GameBoard/Stats/Stats.tsx
@@ -18,8 +18,8 @@ const Stats: FC = () => {
       (item) => item === address,
     );
 
-    if (leaderboardIndex === undefined || leaderboardIndex >= 10) {
-      return ">10";
+    if (leaderboardIndex === undefined || leaderboardIndex > 25) {
+      return ">25";
     }
     return leaderboardIndex + 1;
   }, [leaderboardAddresses]);

--- a/src/components/Sidebar/Leaderboard/Leaderboard.tsx
+++ b/src/components/Sidebar/Leaderboard/Leaderboard.tsx
@@ -3,7 +3,7 @@ import { memo } from "react-tracked";
 
 import { useTrackedState } from "../../../context/store";
 import { useAccount } from "wagmi";
-import { Header, LeaderboardWrapper } from "./styled";
+import { Header, LeaderboardContent, LeaderboardWrapper } from "./styled";
 
 import Row from "./Row";
 
@@ -20,35 +20,37 @@ const Leaderboard = memo(() => {
         <div>Earned</div>
       </Header>
 
-      {leaderboardAddresses?.map((addr, index) => {
-        const item = leaderboardStats[index];
+      <LeaderboardContent>
+        {leaderboardAddresses?.map((addr, index) => {
+          const item = leaderboardStats[index];
 
-        if (index >= 10) {
-          if (addr === address) {
-            return (
-              <Row
-                key={addr}
-                address={addr}
-                index="..."
-                isUser={addr === address}
-                stats={item}
-              />
-            );
+          if (index > 25) {
+            if (addr === address) {
+              return (
+                <Row
+                  key={addr}
+                  address={addr}
+                  index="..."
+                  isUser={addr === address}
+                  stats={item}
+                />
+              );
+            }
+
+            return null;
           }
 
-          return null;
-        }
-
-        return (
-          <Row
-            key={addr}
-            address={addr}
-            index={index + 1}
-            isUser={addr === address}
-            stats={item}
-          />
-        );
-      })}
+          return (
+            <Row
+              key={addr}
+              address={addr}
+              index={index + 1}
+              isUser={addr === address}
+              stats={item}
+            />
+          );
+        })}
+      </LeaderboardContent>
     </LeaderboardWrapper>
   );
 });

--- a/src/components/Sidebar/Leaderboard/styled.ts
+++ b/src/components/Sidebar/Leaderboard/styled.ts
@@ -12,6 +12,27 @@ export const LeaderboardWrapper = styled.div`
   }
 `;
 
+export const LeaderboardContent = styled.div`
+  @media (min-width: 768px) {
+    margin-right: -1.5rem;
+    padding: 0;
+    max-height: 22rem;
+    overflow-y: auto;
+
+    &::-webkit-scrollbar {
+      width: 0.25rem;
+      background-color: #000;
+      border-radius: 0.5rem;
+      right: -1.5rem;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      background-color: #313e57;
+      border-radius: 0.5rem;
+    }
+  }
+`;
+
 export const YouBadge = styled.div`
   display: flex;
   position: absolute;
@@ -41,6 +62,7 @@ export const Header = styled.div`
   font-weight: 600;
   text-align: right;
   margin-bottom: 1rem;
+  padding-right: 1.5rem;
 
   & > :nth-child(1),
   & > :nth-child(2) {
@@ -63,6 +85,7 @@ export const Body = styled.div`
   display: grid;
   width: 100%;
   margin-bottom: 1rem;
+  padding-right: 1.5rem;
 
   font-size: 0.875rem;
   font-weight: 600;

--- a/src/components/Sidebar/Leaderboard/styled.ts
+++ b/src/components/Sidebar/Leaderboard/styled.ts
@@ -42,7 +42,7 @@ export const YouBadge = styled.div`
 
   top: -1.25rem;
 
-  right: 11.5rem;
+  right: 12.5rem;
   padding: 0.25rem 0.5rem;
   flex: 0;
   height: 1.5rem;

--- a/src/components/Sidebar/styled.ts
+++ b/src/components/Sidebar/styled.ts
@@ -18,7 +18,6 @@ export const Wrapper = styled.div`
   @media (min-width: 768px) {
     left: 0;
     right: unset;
-    padding: 1.5rem;
   }
 `;
 
@@ -33,4 +32,15 @@ export const SidebarButton = styled.button`
   border: none;
   padding: 0.5rem;
   cursor: pointer;
+
+  @media (min-width: 768px) {
+    left: 0;
+    right: unset;
+    padding: 1rem;
+    box-shadow: 0px 0px 2rem 0px #2fa9ee33;
+    & > svg {
+      height: 1.25rem;
+      width: 1.25rem;
+    }
+  }
 `;


### PR DESCRIPTION
- show top 25 (websocket already returns this)
- add scrolling as to not make modal to biiiig
- make sidebar buttons larger so they stand out more on desktop

<img width="527" alt="image" src="https://github.com/bitcoin-verse/verse-clicker/assets/3693256/f00173c4-b676-43c9-b0ee-2bc038073db1">

<img width="415" alt="image" src="https://github.com/bitcoin-verse/verse-clicker/assets/3693256/475ab722-f4d8-46bd-8f05-0ae3b84b48dc">
