### PR TITLE
fix leaderboard scroll/padding on mobile

### DIFF
--- a/src/components/Sidebar/Leaderboard/styled.ts
+++ b/src/components/Sidebar/Leaderboard/styled.ts
@@ -85,7 +85,6 @@ export const Body = styled.div`
   display: grid;
   width: 100%;
   margin-bottom: 1rem;
-  padding-right: 1.5rem;
 
   font-size: 0.875rem;
   font-weight: 600;
@@ -107,5 +106,9 @@ export const Body = styled.div`
     justify-content: flex-end;
     align-items: center;
     font-family: monospace;
+  }
+
+  @media (min-width: 768px) {
+    padding-right: 1.5rem;
   }
 `;


### PR DESCRIPTION
only right pad leaderboard if desktop

<img width="524" alt="image" src="https://github.com/bitcoin-verse/verse-clicker/assets/3693256/c5be1dba-a8fb-4f68-9ea3-7e5c1d8aa28d">
