### PR TITLE
[MTDB-12133] Fix flickering svg on leaderboards

### DIFF
--- a/src/components/GameBoard/PointsDisplay/styled.ts
+++ b/src/components/GameBoard/PointsDisplay/styled.ts
@@ -31,6 +31,7 @@ export const Points = styled.div`
   & > svg {
     filter: drop-shadow(0px 0.25rem 1.25rem #ffb800);
     margin-right: 0.5rem;
+    transform: translateZ(0);
   }
 `;
 

--- a/src/components/Sidebar/Leaderboard/styled.ts
+++ b/src/components/Sidebar/Leaderboard/styled.ts
@@ -77,6 +77,7 @@ export const Header = styled.div`
 export const StarWrapper = styled.div`
   & > svg {
     filter: drop-shadow(0px 2px 10px #ffb800);
+    transform: translateZ(0);
   }
 `;
 


### PR DESCRIPTION
**Short Description:**
when using safari mobile, svg is flickering 

**Screenshots (optional):**

https://github.com/bitcoin-verse/verse-clicker/assets/94164690/969984d9-5386-440b-b84a-2df4718aecaf

