### PR TITLE
[MTDB-12332] Fix game reconnection

### DIFF
--- a/src/context/SocketContext.tsx
+++ b/src/context/SocketContext.tsx
@@ -30,6 +30,8 @@ const SocketCtxProvider: FC<PropsWithChildren> = ({ children }) => {
   const { chain } = useNetwork();
   const { address } = useAccount();
   const { gameMode } = useTrackedState();
+  const search = new URLSearchParams();
+  const campaign = search.get("campaign");
 
   const socketRef = useRef(
     io(process.env.REACT_APP_WEBSOCKET_SERVER || "http://localhost:3001", {
@@ -45,10 +47,27 @@ const SocketCtxProvider: FC<PropsWithChildren> = ({ children }) => {
       if (!chain || !address) return;
       console.log("socket connected");
       console.log(chain.name, gameMode);
+
+      if (!campaign && gameMode === "Christmas") {
+        search.append("campaign", "Christmas");
+        dispatch({ type: "SET_GAME_MODE", payload: "Christmas" });
+        window.history.pushState(
+          "campaign=Christmas",
+          "",
+          `${window.location.origin}${window.location.pathname}?${search}`,
+        );
+      }
+
       if (!activeCampaigns.includes(gameMode)) {
         dispatch({ type: "RESET_GAME" });
         dispatch({ type: "SET_GAME_MODE", payload: chain.name as GameMode });
+        window.history.pushState(
+          "",
+          "",
+          `${window.location.origin}${window.location.pathname}`,
+        );
       }
+
       socketRef.current.emit("join", { address, chain: gameMode });
     };
 


### PR DESCRIPTION
**Short Description:**
- add `campaign=Christmas` in url when starting clickmas
- remove `campaign` query when switching back to chains

**Screenshots (optional):**

https://github.com/bitcoin-verse/verse-clicker/assets/94164690/b1bf49fa-bd24-4f80-a8cb-60b98958f7e5

