### PR TITLE
add label to return modal to inform max point production

### DIFF
--- a/src/components/NotificationModal/ReturningUser.tsx
+++ b/src/components/NotificationModal/ReturningUser.tsx
@@ -10,6 +10,7 @@ import { H3 } from "../H3";
 import { DataWrapper, Stats, Value } from "./styled";
 import BonusList from "./BonusList";
 import PointsIcon from "../PointsIcon";
+import { Label } from "../Label";
 
 const ReturningUser = () => {
   const { returnData } = useTrackedState();
@@ -34,6 +35,7 @@ const ReturningUser = () => {
           </Value>
         </Stats>
       </DataWrapper>
+      <Label $color="secondary">12 hours maximum offline point production</Label>
 
       {returnData?.bonus.burn && returnData.bonus.burn.length > 0 && (
         <BonusList isBurn txData={returnData.bonus.burn} />


### PR DESCRIPTION
**Short Description:**

add label to return modal to inform users of max offline point production

**Figma Link (optional):**
N/A

**Screenshots (optional):**
<img width="275" alt="image" src="https://github.com/bitcoin-verse/verse-clicker/assets/3693256/1cbf404b-2fe4-4e74-8218-41fffdd9281a">


**This PR is blocked by or a continuation of:**
PR#