### PR TITLE
[MTDB-12662] Add lounge boost only for lunar new year campaign

### DIFF
--- a/src/components/Boosts/Boosts.tsx
+++ b/src/components/Boosts/Boosts.tsx
@@ -24,6 +24,7 @@ const Scratcher = lazy(() => import("./Modals/Scratcher"));
 const ScratcherLunar = lazy(() => import("./Modals/ScratcherLunar"));
 const ScratcherMint = lazy(() => import("./Modals/ScratcherMint"));
 const Burn = lazy(() => import("./Modals/Burn"));
+const Lounge = lazy(() => import("./Modals/Lounge"));
 
 const boostList = (player: Player, network: GameMode) => {
   switch (network) {
@@ -58,6 +59,12 @@ const boostList = (player: Player, network: GameMode) => {
           unlocked: player.verseHolder,
           label: "Hold",
           description: "8x clicks",
+        },
+        {
+          id: "lounge",
+          unlocked: player.isGuildMember,
+          label: "Lounge",
+          description: "Unlock upgrades",
         },
         {
           id: "scratcher-mint",
@@ -135,6 +142,11 @@ const getModalContent = (content?: string) => {
       return {
         title: "Scratcher Buy",
         component: <ScratcherMint />,
+      };
+    case "lounge":
+      return {
+        title: "Verse Lounge",
+        component: <Lounge />,
       };
     default:
       return null;

--- a/src/components/Boosts/Boosts.tsx
+++ b/src/components/Boosts/Boosts.tsx
@@ -106,7 +106,7 @@ const boostList = (player: Player, network: GameMode) => {
   }
 };
 
-const getModalContent = (content?: string) => {
+const getModalContent = (close: () => void, content?: string) => {
   switch (content) {
     case "burn":
       return {
@@ -146,7 +146,7 @@ const getModalContent = (content?: string) => {
     case "lounge":
       return {
         title: "Verse Lounge",
-        component: <Lounge />,
+        component: <Lounge close={close} />,
       };
     default:
       return null;
@@ -159,11 +159,11 @@ interface Props {
 
 const Boosts: FC<Props> = ({ mobileVersion }) => {
   const [content, setContent] = useState<string>();
-  const { modalRef, showModal } = useModal();
+  const { modalRef, showModal, close } = useModal();
   const { chain } = useNetwork();
   const { player, gameMode } = useTrackedState();
 
-  const modalContent = getModalContent(content);
+  const modalContent = getModalContent(close, content);
   const interactiveBoosts = [
     "burn",
     "scratcher",

--- a/src/components/Boosts/Modals/Lounge.tsx
+++ b/src/components/Boosts/Modals/Lounge.tsx
@@ -1,0 +1,86 @@
+import React, { FC } from "react";
+import {
+  GUILD_URL,
+  VERSE_LOUNGE_URL,
+  VERSE_MARKETS_DEEPLINK,
+} from "src/constants";
+
+import { useTrackedState } from "../../../context/store";
+import { logAmplitudeEvent } from "../../../helpers/analytics";
+import { H3 } from "../../H3";
+import { Label } from "../../Label";
+import LinkButton from "../../LinkButton";
+import { ModalWrapper } from "../styled";
+
+interface Props {
+  close: () => void;
+}
+const Lounge: FC<Props> = ({ close }) => {
+  const { player } = useTrackedState();
+
+  return (
+    <ModalWrapper>
+      {player.isGuildMember ? (
+        <>
+          <H3>You are a certified Verse Lounge member</H3>
+          <Label $color="secondary">
+            Congratulations, you have access to all the tools!
+          </Label>
+          <LinkButton
+            href={VERSE_LOUNGE_URL}
+            newTab
+            onClick={() => {
+              logAmplitudeEvent({
+                name: "verse clicker cta tapped",
+                cta: "lounge",
+                to: VERSE_LOUNGE_URL,
+              });
+            }}
+          >
+            Go to Lounge
+          </LinkButton>
+          <LinkButton design="secondary" onClick={close}>
+            Back to game
+          </LinkButton>
+        </>
+      ) : (
+        <>
+          <H3>You are not currently a Verse Lounge member</H3>
+          <Label $color="secondary">
+            By joining Verse Lounge, you&#39;ll get instant access to all
+            in-game tools!
+          </Label>
+          <LinkButton
+            href={GUILD_URL}
+            newTab
+            onClick={() => {
+              logAmplitudeEvent({
+                name: "verse clicker cta tapped",
+                cta: "guild",
+                to: GUILD_URL,
+              });
+            }}
+          >
+            Become a Verse Lounge Guild Member
+          </LinkButton>
+          <LinkButton
+            design="secondary"
+            href={VERSE_MARKETS_DEEPLINK}
+            newTab
+            onClick={() => {
+              logAmplitudeEvent({
+                name: "verse clicker cta tapped",
+                cta: "markets",
+                to: VERSE_MARKETS_DEEPLINK,
+              });
+            }}
+          >
+            Get VERSE
+          </LinkButton>
+        </>
+      )}
+    </ModalWrapper>
+  );
+};
+
+export default Lounge;

--- a/src/components/Boosts/Modals/Lounge.tsx
+++ b/src/components/Boosts/Modals/Lounge.tsx
@@ -61,7 +61,7 @@ const Lounge: FC<Props> = ({ close }) => {
               });
             }}
           >
-            Become a Verse Lounge Guild Member
+            Become a Verse Lounge Member
           </LinkButton>
           <LinkButton
             design="secondary"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,11 @@
 import { GameMode } from "./context/reducers/network";
 
+const VERSE_BASE_URL =
+  process.env.REACT_APP_VERSE_BASE_URL || "https://verse.bitcoin.com/";
+
 export const CURRENT_CAMPAIGN: GameMode = "LunarNewYear";
+
+export const GUILD_URL = "https://guild.xyz/verse";
+export const VERSE_MARKETS_DEEPLINK =
+  "bitcoincom://markets/ETH_BLOCKCHAIN-ERC_20_PROTOCOL-0x249ca82617ec3dfb2589c4c17ab7ec9765350a18";
+export const VERSE_LOUNGE_URL = `${VERSE_BASE_URL}lounge/`;


### PR DESCRIPTION
**Short Description:**
- add lounge boost for guild members
- this boost is only enabled during lunar new year


**Screenshots (optional):**
<img width="629" alt="Screenshot 2024-01-19 at 14 25 13" src="https://github.com/bitcoin-verse/verse-clicker/assets/94164690/86625ad3-c855-4bea-b046-1c8b64772064">
<img width="426" alt="Screenshot 2024-01-19 at 14 25 24" src="https://github.com/bitcoin-verse/verse-clicker/assets/94164690/e574aa8e-a7a1-4bb7-b583-b73c00fb8d07">
<img width="414" alt="Screenshot 2024-01-19 at 14 26 33" src="https://github.com/bitcoin-verse/verse-clicker/assets/94164690/b5b954af-d0d1-4802-a8ca-2f5c0b093241">
