### PR TITLE
[MTDB-12670] Remove decimal on clicks and stats

### DIFF
--- a/src/components/GameBoard/Cookie/Cookie.tsx
+++ b/src/components/GameBoard/Cookie/Cookie.tsx
@@ -43,7 +43,7 @@ const Cookie: FC = () => {
             top: y,
           }}
         >
-          +{formatNumber(player.cpc)}
+          +{Number(formatNumber(player.cpc)).toFixed()}
         </CpcClick>,
       );
 

--- a/src/components/GameBoard/Stats/Stats.tsx
+++ b/src/components/GameBoard/Stats/Stats.tsx
@@ -39,7 +39,9 @@ const Stats: FC = () => {
         </div>
         <div>
           <Label $color="secondary">Clicked</Label>
-          <Subtitle>{formatNumber(player.stats.Clicked)}</Subtitle>
+          <Subtitle>
+            {Number(formatNumber(player.stats.Clicked)).toFixed()}
+          </Subtitle>
         </div>
         <div>
           <Label $color="secondary">Spent</Label>


### PR DESCRIPTION
**Short Description:**
- make it a whole number

**Screenshots (optional):**
<img width="381" alt="Screenshot 2024-01-19 at 14 39 11" src="https://github.com/bitcoin-verse/verse-clicker/assets/94164690/64cabfeb-d9e2-4072-8fee-8f73c8529b35">

https://github.com/bitcoin-verse/verse-clicker/assets/94164690/3d0a9a4e-ce54-486e-9535-1aab4d2eed56

