### PR TITLE
[MTDB-12675] remove locale arg from date localization

### DIFF
--- a/src/components/NotificationModal/BonusList.tsx
+++ b/src/components/NotificationModal/BonusList.tsx
@@ -69,7 +69,7 @@ const BonusList: FC<Props> = ({ txData, bonusType }) => {
           return (
             <Fragment key={data.txHash}>
               <div>
-                {new Date(data.date).toLocaleDateString("en-US", {
+                {new Date(data.date).toLocaleDateString(undefined, {
                   dateStyle: "short",
                 })}
               </div>


### PR DESCRIPTION
**Short Description:**
looks like this was the only date localization that specified `en-US`

**Figma Link (optional):**
N/A

**Screenshots (optional):**
N/A

**This PR is blocked by or a continuation of:**
PR#