### PR TITLE
[MTDB-12671] Fix overlapping banner on mobile

### DIFF
--- a/src/components/Banners/styled.ts
+++ b/src/components/Banners/styled.ts
@@ -5,7 +5,7 @@ import { colors } from "../colors";
 export const Wrapper = styled.div`
   box-sizing: border-box;
   grid-area: banner;
-  z-index: 100;
+  z-index: 1;
   width: 100%;
   background-color: ${colors.primaryBlue100};
   padding: 10px 16px;


### PR DESCRIPTION
**Short Description:**
- put modal on top 

**Screenshots (optional):**
<img width="355" alt="Screenshot 2024-01-22 at 16 23 59" src="https://github.com/bitcoin-verse/verse-clicker/assets/94164690/31f56d70-d6dc-4b8a-a842-69a0f896e0db">

