### PR TITLE
[MTDB-12836] Remove Get Verse button in lounge modal

### DIFF
--- a/src/components/Boosts/Modals/Lounge.tsx
+++ b/src/components/Boosts/Modals/Lounge.tsx
@@ -63,20 +63,6 @@ const Lounge: FC<Props> = ({ close }) => {
           >
             Become a Verse Lounge Member
           </LinkButton>
-          <LinkButton
-            design="secondary"
-            href={VERSE_MARKETS_DEEPLINK}
-            newTab
-            onClick={() => {
-              logAmplitudeEvent({
-                name: "verse clicker cta tapped",
-                cta: "markets",
-                to: VERSE_MARKETS_DEEPLINK,
-              });
-            }}
-          >
-            Get VERSE
-          </LinkButton>
         </>
       )}
     </ModalWrapper>


### PR DESCRIPTION
**Short Description:**
- remove "Get Verse" button

**Screenshots (optional):**

<img width="453" alt="Screenshot 2024-01-31 at 9 58 11" src="https://github.com/bitcoin-verse/verse-clicker/assets/94164690/d1023c7d-e9f4-4666-b5e9-f7505b98a842">

