### PR TITLE
[MTDB-12909] Display user local's offset on campaign modal dates

### DIFF
--- a/src/components/Campaigns/Before.tsx
+++ b/src/components/Campaigns/Before.tsx
@@ -22,11 +22,17 @@ const Before: FC<Props> = ({ campaignInfo, content }) => {
         <>
           <Text>
             {content.start}
-            {new Date(campaignInfo.startDate).toLocaleString()}
+            {new Date(campaignInfo.startDate).toLocaleString(undefined, {
+              dateStyle: "short",
+              timeStyle: "long",
+            })}{" "}
           </Text>
           <Text>
             {content.end}
-            {new Date(campaignInfo.endDate).toLocaleString()}
+            {new Date(campaignInfo.endDate).toLocaleString(undefined, {
+              dateStyle: "short",
+              timeStyle: "long",
+            })}{" "}
           </Text>
         </>
       )}

--- a/src/components/Campaigns/During.tsx
+++ b/src/components/Campaigns/During.tsx
@@ -34,7 +34,11 @@ const During: FC<Props> = ({
       {campaignInfo && (
         <>
           <Text>
-            {content.end} {new Date(campaignInfo.endDate).toLocaleString()}
+            {content.end}
+            {new Date(campaignInfo.endDate).toLocaleString(undefined, {
+              dateStyle: "short",
+              timeStyle: "long",
+            })}
           </Text>
         </>
       )}


### PR DESCRIPTION
**Short Description:**
- display so users wont get confused

**Screenshots (optional):**
<img width="1723" alt="Screenshot 2024-02-08 at 15 19 22" src="https://github.com/bitcoin-verse/verse-clicker/assets/94164690/845a882a-d16b-4533-a754-c5e69d035dfd">
