### PR TITLE
[MTDB-12871] Fix tools amount & cost when changing multiplier

### DIFF
--- a/src/components/Shop/ShopList/BuildingButton/BuildingButton.tsx
+++ b/src/components/Shop/ShopList/BuildingButton/BuildingButton.tsx
@@ -45,7 +45,7 @@ export const BuildingButton: FC<Props> = ({ building, index }) => {
     }
 
     return getMaxBuilding(player.cookies, building.cost);
-  }, [player.cookies, building.cost]);
+  }, [purchaseAmount, player.cookies, building.cost]);
 
   const farmStakingMultiplier = player.isFarming || player.isStaking ? 2 : 1;
 


### PR DESCRIPTION
**Short Description:**
- add `purchaseAmount` as a dependency in `useMemo` so the tools amount & cost change when the multiplier changes


**Screenshots (optional):**

https://github.com/bitcoin-verse/verse-clicker/assets/94164690/65704a59-17f9-418d-8937-c50f2f531a4c

