### PR TITLE
Remove banner when there's no current campaign

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,4 +1,5 @@
 import React, { FC, PropsWithChildren } from "react";
+import { CURRENT_CAMPAIGN } from "src/constants";
 import { ThemeProvider } from "styled-components";
 
 import { AudioProvider } from "../../context/AudioProvider";
@@ -19,7 +20,9 @@ const Layout: FC<PropsWithChildren> = ({ children }) => {
       <AudioProvider>
         <ContentsWrapper>
           <GlobalStyle />
-          {campaignBanner && campaignPhase !== "AFTER" && <Banner />}
+          {campaignBanner &&
+            campaignPhase !== "AFTER" &&
+            CURRENT_CAMPAIGN !== undefined && <Banner />}
           {children}
         </ContentsWrapper>
       </AudioProvider>


### PR DESCRIPTION
**Short Description:**
- there was a weird "learn more" banner that's not clickable lol

**Screenshots (optional):**
<img width="1725" alt="Screenshot 2024-08-02 at 15 29 29" src="https://github.com/user-attachments/assets/9520f318-9e83-46d0-ba56-4e10f8715db0">
